### PR TITLE
Delete .release

### DIFF
--- a/.release
+++ b/.release
@@ -1,4 +1,0 @@
-#!/bin/sh
-# This file is executed by the `release` script from
-# https://github.com/gap-system/ReleaseTools
-rm -rf .travis.yml .codecov.yml


### PR DESCRIPTION
All this does is already taken care of by the current ReleaseTools version