### PR TITLE
This package requires at least GAP 4.10

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -91,10 +91,10 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.8.0",
+  GAP := ">=4.10",
   NeededOtherPackages := [["automata", ">=0.0.0"],
                           ["digraphs", ">=0.15.0"],
-			                    ["fr", ">=2.4.6"],
+                          ["fr", ">=2.4.6"],
                           ["aaa", ">=0.0.0"],
                           ["datastructures", ">= 0.2.5"]],
   SuggestedOtherPackages := [],


### PR DESCRIPTION
... because Digraphs requires GAP 4.10
