### PR TITLE
Improve PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -7,13 +7,6 @@
 # manual of the "Example" package as well as the comments in its
 # PackageInfo.g file.
 #
-##  <#GAPDoc Label="PKGVERSIONDATA">
-##  <!ENTITY VERSION "0.1.0">
-##  <!ENTITY GAPVERS "4.8.0">
-##  <!ENTITY ARCHIVENAME "autshift-0.1.0">
-##  <!ENTITY COPYRIGHTYEARS "2022">
-##  <#/GAPDoc>
-
 
 SetPackageInfo( rec(
 
@@ -23,14 +16,25 @@ Version := "0.1.0",
 Date := "12/07/2022", # dd/mm/yyyy format
 License := "GPL-3.0-or-later",
 
-AutoDoc := rec(TitlePage := rec(Abstract:= 
-   "The autshift package is a GAP package containing methods for transducers that can be used\
-     to represent isomorphisms between subshifts of finite type and related objects. It implements the\
-    some of processes described in the papers https://arxiv.org/abs/2004.08478v4by and https://arxiv.org/abs/2112.13359\
-    and builds on the existing package https://github.com/gap-packages/aaa.",
-   Acknowledgements:= 
-      "This package was created by Luke Elliott under the funding of ESPRC grant EP/R032866/1 and supervised by Collin Bleak. Special thanks to James Mitchell and Michael Torpey for their technical support.")),
-
+AutoDoc := rec(
+  TitlePage := rec(
+    Abstract :=
+      """
+      The &autshift; package is a &GAP; package containing methods for
+      transducers that can be used to represent isomorphisms between subshifts
+      of finite type and related objects. It implements the some of processes
+      described in the papers <URL>https://arxiv.org/abs/2004.08478</URL> and
+      <URL>https://arxiv.org/abs/2112.13359</URL> and builds on the &GAP;
+      package <URL Text="aaa">https://github.com/gap-packages/aaa</URL>.
+      """,
+    Acknowledgements :=
+      """
+      This package was created by Luke Elliott under the funding of ESPRC
+      grant EP/R032866/1 and supervised by Collin Bleak. Special thanks to
+      James Mitchell and Michael Torpey for their technical support.
+      """,
+    ),
+),
 
 Persons := [
   rec(
@@ -66,27 +70,16 @@ ArchiveURL      := Concatenation( ~.SourceRepository.URL,
 
 ArchiveFormats := ".tar.gz",
 
-##  Status information. Currently the following cases are recognized:
-##    "accepted"      for successfully refereed packages
-##    "submitted"     for packages submitted for the refereeing
-##    "deposited"     for packages for which the GAP developers agreed
-##                    to distribute them with the core GAP system
-##    "dev"           for development versions of packages
-##    "other"         for all other packages
-##
-Status := "dev",
-#AutoDoc
-#    This is a record which can be used to control the scaffolding performed by
-# AutoDoc, specifically to provide extra information for the title page. 
-#For example, you can set AutoDoc.TitlePage.Copyright to a string which will then
-#  be inserted on the generated title page. Using this method you can customize the following title page elements: TitleComment, Abstract, Copyright, Acknowledgements and Colophon.
-#    Note that AutoDoc.TitlePage behaves exactly the same as the scaffold.TitlePage parameter of the AutoDoc (4.1-1) function.
-
 AbstractHTML :=  
-"The autshift package is a GAP package containing methods for transducers that can be used\
-  to represent isomorphisms between subshifts of finite type and related objects. It implements the\
- some of processes described in the papers https://arxiv.org/abs/2004.08478v4by and https://arxiv.org/abs/2112.13359\
- and builds on the existing package https://github.com/gap-packages/aaa.",
+      """
+      The <span class="pkgname">autshift</span> package is a GAP package containing methods for
+      transducers that can be used to represent isomorphisms between
+      subshifts of finite type and related objects. It implements the
+      some of processes described in the papers
+      <a href="https://arxiv.org/abs/2004.08478">https://arxiv.org/abs/2004.08478</a> and
+      <a href="https://arxiv.org/abs/2112.13359">https://arxiv.org/abs/2112.13359</a> and
+      builds on the GAP package <a href="https://github.com/gap-packages/aaa">aaa</a>.
+      """,
 
 PackageDoc := rec(
   BookName  := ~.PackageName,
@@ -107,24 +100,6 @@ Dependencies := rec(
   SuggestedOtherPackages := [],
   ExternalConditions := []),
 
-##BannerString := Concatenation(
-##  "----------------------------------------------------------------------",
-##  "-------\n",
-##  "Loading  autshift ", ~.Version, "\n",
-##  "by ", ~.Persons[1].FirstNames, " ", ~.Persons[1].LastName,
-##        " (", ~.Persons[1].WWWHome, ")\n",
-##  "with contributions by:\n",
-##  Concatenation(Concatenation(List(~.Persons{[2 .. Length(~.Persons) - 1]},
-##       p -> ["     ", p.FirstNames, " ", p.LastName,
-##       _RecogsFunnyNameFormatterFunction(
-##         _RecogsFunnyWWWURLFunction(p)), ",\n"]))),
-##  " and ", ~.Persons[Length(~.Persons)].FirstNames, " ",
-##  ~.Persons[Length(~.Persons)].LastName,
-##  _RecogsFunnyNameFormatterFunction(
-##    _RecogsFunnyWWWURLFunction(~.Persons[Length(~.Persons)])), ".\n",
-##  "-----------------------------------------------------------------------",
-##  "------\n"),
-
 AvailabilityTest := ReturnTrue,
 
 TestFile := "tst/testall.g",
@@ -132,4 +107,3 @@ TestFile := "tst/testall.g",
 #Keywords := [ "TODO" ],
 
 ));
-


### PR DESCRIPTION
- drop unused GAPDoc block PKGVERSIONDATA
- mark URLs as such in XML and HTML
- also fix one arXiv URL (2004.08478v4by -> 2004.08478)
- drop obsolete `Status` field
